### PR TITLE
mainから/insert_cocktailでinsertページいけるように。htmlにbootstrap実装?

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"github.com/gin-gonic/gin"
+	"net/http"
 )
 
 var DB = make(map[string]string)
 
-func setupRouter() *gin.Engine {
+func setupr() *gin.Engine {
 	// Disable Console Color
 	// gin.DisableConsoleColor()
 	r := gin.Default()
@@ -56,8 +57,17 @@ func setupRouter() *gin.Engine {
 	return r
 }
 
+type C struct {
+  Id int
+  Name string
+}
+
 func main() {
-	r := setupRouter()
+	r := setupr()
+	r.LoadHTMLGlob("view/html/*.html")
+  r.GET("/insert_cocktail", func(c *gin.Context) {
+    c.HTML(http.StatusOK, "insert_cocktail.html", gin.H{})
+  })
 	// Listen and Server in 0.0.0.0:8080
 	r.Run(":8080")
 }

--- a/view/html/insert_cocktail.html
+++ b/view/html/insert_cocktail.html
@@ -1,0 +1,39 @@
+<html>
+ <head>
+  <title>カクテル追加</title>
+<!--  <link rel="stylesheet" type="text/css" href="../css/style.css"> -->
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" rel="stylesheet">
+
+ </head>
+ <body>
+   <h1 class="title">Fuck you</h1>
+   <form action="../javascript/insert.js" method="post">
+    <ul class="insert">
+      <li>カクテル名：<input type="text" name="name" placeholder="ジントニック"></li>
+      <p>ベース
+        <li>名前：<input type="text" name="bace-name" placeholder="ジン"></li>
+        <li>分量：<input type="number" name="bace-vol" placeholder="60">ml</li>
+      </p>
+      <p>割り材
+        <li>割り材名：<input type="text" name="timber-name-1" placeholder="氷"></li>
+        <li>分量：<input type="number" name="timber-vol-1" placeholder="20">ml</li>
+        <li>割り材名：<input type="text" name="timber-name-2" placeholder="トニックウォーター"></li>
+        <li>分量：<input type="number" name="timber-vol-2" placeholder="20">ml</li>
+        <li>割り材名：<input type="text" name="timber-name-3" placeholder="氷"></li>
+        <li>分量：<input type="number" name="timber-vol-3" placeholder="20">ml</li>
+        <li>割り材名：<input type="text" name="timber-name-4" placeholder="氷"></li>
+        <li>分量：<input type="number" name="timber-vol-4" placeholder="20">ml</li>
+        <li>割り材名：<input type="text" name="timber-name-5" placeholder="氷"></li>
+        <li>分量：<input type="number" name="timber-vol-5" placeholder="20">ml</li>
+      </p>
+      <p>コメント
+        <li>説明：<input type="text" name="comment" placeholder="すっきりした味わい"></li>
+      </p>
+    </ul>
+    <input type="submit" value="送信">
+  </form>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.bundle.min.js"></script>
+
+ </body>
+</html>


### PR DESCRIPTION
main実行してlocalhost:8080/insert_cocktail　からカクテル入力画面に移動可能
insert_cocktail.htmlにCDNでbootstrapを実装
　-活用はいまいちできてない